### PR TITLE
Improved stability of flashing

### DIFF
--- a/bootloader.h
+++ b/bootloader.h
@@ -16,7 +16,7 @@ uint8_t data[60];																// copy of received data
 uint8_t hasData = 0;															// flag indicate if we received data for our address
 
 uint16_t timeoutCounter = 0;
-
+uint16_t timeoutReinitCounter = 0;
 #define MSG_RESPONSE_TYPE_ACK         0x00
 #define MSG_RESPONSE_TYPE_NACK        0x80
 
@@ -34,7 +34,8 @@ uint8_t hmCheckAndDecodeData();
 void hmEncodeAndSendData(uint8_t *msg);
 void sendResponse(uint8_t *msg, uint8_t type);
 void startApplication();
-void startApplicationOnTimeout();
+void startApplicationOnTimeout(uint8_t seconds);
+void reinitCC1101OnTimeout();
 void sendBootloaderSequence();
 void waitForCbMsg();
 void switch_radio_to_100k_mode();


### PR DESCRIPTION
Sometimes the CC1101 seems to hang up and don't receives any messages anymore.
So I added a timeout which reinits the CC1101 after 3 seconds, when nothing has beeen received.
Additionaly I increased the start application timeout when flashing hasbeen started.
In combination with some changes at the flashing tool, much more retries can be made.
At the end I modified the sending and receiving routines so that they match with the code from the asksinpplib.

After the CC1101 timeout is implemented, flashing looks like this:

```
AskSin OTA Bootloader V0.7.0

TX bootloader sequence
Wait for CB msg
Got CB msg
Switch to 100k mode
Wait for CB msg
Got CB msg
Receive firmware
...............................................................CC1101 Timeout
............................CC1101 Timeout
To many data for pageSize
blockLen differ pageSize
................................................................CC1101 Timeout
To many data for pageSize
blockLen differ pageSize
blockLen differ pageSize
blockLen differ pageSize
.............................Retransmit, reflash!
........CC1101 Timeout
...................Retransmit, reflash!
.....CC1101 Timeout
.....Retransmit, reflash!
......CC1101 Timeout
CC1101 Timeout
Timeout
CRC OK
Start App
AskSin++ V4.1.1 (Oct 10 2019 12:55:39)
```
